### PR TITLE
Update PeekAndPop.java

### DIFF
--- a/library/src/main/java/com/peekandpop/shalskar/peekandpop/PeekAndPop.java
+++ b/library/src/main/java/com/peekandpop/shalskar/peekandpop/PeekAndPop.java
@@ -289,6 +289,14 @@ public class PeekAndPop {
             onGeneralActionListener.onPeek(longClickView, index);
 
         peekLayout.setVisibility(View.VISIBLE);
+        
+		MotionEvent e = MotionEvent.obtain(SystemClock.uptimeMillis(),
+    		SystemClock.uptimeMillis(),
+    		MotionEvent.ACTION_CANCEL,
+    		10, 10, 0);
+		longClickView.onTouchEvent(e);
+		e.recycle();
+
 
         if (Build.VERSION.SDK_INT >= 17 && blurBackground)
             blurBackground();


### PR DESCRIPTION
send cancel touch event to the long clicked view
it should send this touch event because when not sent the view remains in pressed state and that's not good
